### PR TITLE
Add MMU1 test

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -5,7 +5,7 @@ disk = [ FDirName $(SUBDIR) craigtst.dsk ] ;
 
 ASM = [ Glob $(SUBDIR) : *.asm ] ;
 
-TARGETS = i1.asm i2.asm i3.asm kbchk.asm ;
+TARGETS = i1.asm i2.asm i3.asm kbchk.asm mmu1.asm ;
 
 DEPS = $(DEP:S=.asm) ;
 

--- a/Jamrules
+++ b/Jamrules
@@ -9,7 +9,7 @@ if $(OS) = NT
 
 	# tool paths
 	LWTOOLS_PATH	= [ FDirName $(TOOL_PATH) lwtools-4.24c ] ;
-	TOOLSHED_PATH	= [ FDirName $(TOOL_PATH) toolshed-2.4.2 ] ;
+	TOOLSHED_PATH	= [ FDirName $(TOOL_PATH) toolshed-2.5.1 ] ;
 	VCC_PATH		= [ FDirName $(TOOL_PATH) vcc-2.1.9.1 ] ;
 	XROAR_PATH		= [ FDirName $(TOOL_PATH) xroar-1.8.1 ] ;
 }

--- a/clear.asm
+++ b/clear.asm
@@ -6,19 +6,19 @@
 
 
 cleartop
-	pshs	a,b,x
-	ldd	#$2020
-	ldx	#screen
-.loop   std	,x++
-	cmpx	#screen+8*32
-	bne	.loop
-	puls	a,b,x,pc
+        pshs    a,b,x
+        ldd     #$2020
+        ldx     #screen
+.loop   std     ,x++
+        cmpx    #screen+8*32
+        bne     .loop
+        puls    a,b,x,pc
 
-clear   pshs	a,b,x
-	ldd	#$2020
-	ldx	#screen
-.loop   std	,x++
-	cmpx	#escreen
-	bne	.loop
-	puls	a,b,x,pc
+clear   pshs    a,b,x
+        ldd     #$2020
+        ldx     #screen
+.loop   std     ,x++
+        cmpx    #escreen
+        bne     .loop
+        puls    a,b,x,pc
 

--- a/crc16.asm
+++ b/crc16.asm
@@ -7,17 +7,17 @@
 * Craig Allsop - 2025/05/20
 **************************************************************************
 
-crc16 	pshs	y
-@top:	eora	,u+
-	ldy	#8
+crc16   pshs    y
+@top:   eora    ,u+
+        ldy     #8
 @loop:  aslb
-	rola
-	bcc	@skip
-	eora	#$10
-	eorb	#$21
-@skip:  leay	-1,y
-	bne	@loop
-	leax	-1,x
-	bne	@top
-	puls	y,pc
+        rola
+        bcc     @skip
+        eora    #$10
+        eorb    #$21
+@skip:  leay    -1,y
+        bne     @loop
+        leax    -1,x
+        bne     @top
+        puls    y,pc
 

--- a/crc16.asm
+++ b/crc16.asm
@@ -7,16 +7,17 @@
 * Craig Allsop - 2025/05/20
 **************************************************************************
 
-crc16 	eora	,u+
+crc16 	pshs	y
+@top:	eora	,u+
 	ldy	#8
-.loop   aslb
+@loop:  aslb
 	rola
-	bcc	.skip
+	bcc	@skip
 	eora	#$10
 	eorb	#$21
-.skip   leay	-1,y
-	bne	.loop
+@skip:  leay	-1,y
+	bne	@loop
 	leax	-1,x
-	bne	crc16
-	rts
+	bne	@top
+	puls	y,pc
 

--- a/expandtabs.sh
+++ b/expandtabs.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+function fix_tabs () {
+	echo Processing... $1
+	expand $1 > $1.1
+	cp $1.1 $1
+	rm $1.1
+}
+
+export -f fix_tabs
+ls -1 *.asm | xargs -n1 bash -c 'fix_tabs "$@"' _
+

--- a/finish.asm
+++ b/finish.asm
@@ -4,14 +4,14 @@
 *
 * Craig Allsop - 2025/05/20
 **************************************************************************
-finish	ldy	>oldirq
-	sty	>$10d
-	bsr	cleartop
-	ldu	#escreen-2
-	bsr	addchk
-	std	>result
-	ldy	#results
-	ldx	,y++
-	bsr	print
-	bsr	printhexd
-	rts
+finish  ldy     >oldirq
+        sty     >$10d
+        bsr     cleartop
+        ldu     #escreen-2
+        bsr     addchk
+        std     >result
+        ldy     #results
+        ldx     ,y++
+        bsr     print
+        bsr     printhexd
+        rts

--- a/finish.asm
+++ b/finish.asm
@@ -4,12 +4,12 @@
 *
 * Craig Allsop - 2025/05/20
 **************************************************************************
-finish	ldy	oldirq
-	sty	$10d
+finish	ldy	>oldirq
+	sty	>$10d
 	bsr	cleartop
 	ldu	#escreen-2
 	bsr	addchk
-	std	result
+	std	>result
 	ldy	#results
 	ldx	,y++
 	bsr	print

--- a/i1.asm
+++ b/i1.asm
@@ -33,170 +33,170 @@
 * Craig Allsop, 2025-05-19 - v1.0 - program verification checksum = 8C4D
 **************************************************************************
 
-	org	$4000
+        org     $4000
 
 **************************************************************************
 * setup screen
 *
 
-start	bra	.start1
-	fcc	'CA'
-result	fdb	0
+start   bra     .start1
+        fcc     'CA'
+result  fdb     0
 .start1
-	lbsr	clear		clear screen
+        lbsr    clear           clear screen
 
-	ldy	#msgs		print messages to screen
-	ldx	,y++
-.msgs   lbsr	print
-	ldx	,y++
-	bne	.msgs
+        ldy     #msgs           print messages to screen
+        ldx     ,y++
+.msgs   lbsr    print
+        ldx     ,y++
+        bne     .msgs
 
-	lda	#60		program initialization
-	sta	>count1
-	sta	>count2
-	ldx	>timer+2
-	stx	>timer
-	ldd	#0
-	std	>data
-	std	>result
-	std	>oldirq
-	std	>check
+        lda     #60             program initialization
+        sta     >count1
+        sta     >count2
+        ldx     >timer+2
+        stx     >timer
+        ldd     #0
+        std     >data
+        std     >result
+        std     >oldirq
+        std     >check
 
-	ldu	#start		program check
-	ldx	#last-start
-	lbsr	crc16
-	ldx	#screen+10*32+24
-	lbsr	printhexd
-	lda	#$30		count = 0
-	sta	>counter1
-	sta	>counter2
-	ldx	>$10d
-	stx	>oldirq
-	ldx	#intr1
-	stx	>$10d		install irq handler
-	lda	#7
-	sta	>$ff03
-	clra
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
+        ldu     #start          program check
+        ldx     #last-start
+        lbsr    crc16
+        ldx     #screen+10*32+24
+        lbsr    printhexd
+        lda     #$30            count = 0
+        sta     >counter1
+        sta     >counter2
+        ldx     >$10d
+        stx     >oldirq
+        ldx     #intr1
+        stx     >$10d           install irq handler
+        lda     #7
+        sta     >$ff03
+        clra
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
 
 **************************************************************************
 * start of main program
 *
-top	ldy	>timer
-	leay	-1,y
-	lbeq	finish
-	sty	>timer
-	tst	>$ff02		reset for next interrupt
-	ldx	#screen
-	sta	,x+
-	andcc   #$ef		enable irq & push this state
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
+top     ldy     >timer
+        leay    -1,y
+        lbeq    finish
+        sty     >timer
+        tst     >$ff02          reset for next interrupt
+        ldx     #screen
+        sta     ,x+
+        andcc   #$ef            enable irq & push this state
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
 
 .wait   sync
-.loop	nop			<- instruction at 4060 - interrupts here
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	ldy	#intr1		swap to first irq handler
-	sty	>$10d		install irq handler
-	sta	,x+
-	inca
-	cmpx	#screen+8*32
-	bne	.loop
-	ldx	#screen+15*32+6
-	pshs	a
-	ldd	#$2020
-	std	,x++
-	std	,x++
-	puls	a
-	jmp	>top
+.loop   nop                     <- instruction at 4060 - interrupts here
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        ldy     #intr1          swap to first irq handler
+        sty     >$10d           install irq handler
+        sta     ,x+
+        inca
+        cmpx    #screen+8*32
+        bne     .loop
+        ldx     #screen+15*32+6
+        pshs    a
+        ldd     #$2020
+        std     ,x++
+        std     ,x++
+        puls    a
+        jmp     >top
 
-	INCLUDE irq.asm
+        INCLUDE irq.asm
 
-addchk	ldd	>check
-	ldx	#2
-	bsr	crc16
-	std	>check
-	rts
+addchk  ldd     >check
+        ldx     #2
+        bsr     crc16
+        std     >check
+        rts
 
-	INCLUDE finish.asm
+        INCLUDE finish.asm
 
 **************************************************************************
 
-	INCLUDE	printhex.asm
-	INCLUDE	print.asm
-	INCLUDE crc16.asm
-	INCLUDE clear.asm
+        INCLUDE printhex.asm
+        INCLUDE print.asm
+        INCLUDE crc16.asm
+        INCLUDE clear.asm
 
-count1  fcb	60
-count2  fcb	60
+count1  fcb     60
+count2  fcb     60
 
-timer	fdb	601
-	fdb	601
-oldirq	fdb	0
-data	fdb	0
-check	fdb	0
+timer   fdb     601
+        fdb     601
+oldirq  fdb     0
+data    fdb     0
+check   fdb     0
 
-screen  equ	$400
-escreen equ	$600
-counter1 equ	escreen-2
-counter2 equ	escreen-1
-msgs	fdb	screen+1
-	fcc	' <- SHOULD BE ONE @ HERE'
-	fcb	0
-	fdb	screen+9*32
-	fcc	'     TEST #1 SYNC IRQ V1.0      '
-	fcc	'   CRAIG ALLSOP - 2025 (....)'
-	fcb	0
-	fdb	screen+12*32
-	fcc	'              INTERRUPT ADDRESS '
-	fcc	' 4090.4090 <- SHOULD MATCH THIS'
-	fcb	0
-	fdb	screen+15*32
-	fcc	'[    .    ]   SECONDS (0-9) ->'
-	fcb	0
-	fdb	0
-results	fdb	screen
-	fcc	'RESULT = '
-	fcb	0
+screen  equ     $400
+escreen equ     $600
+counter1 equ    escreen-2
+counter2 equ    escreen-1
+msgs    fdb     screen+1
+        fcc     ' <- SHOULD BE ONE @ HERE'
+        fcb     0
+        fdb     screen+9*32
+        fcc     '     TEST #1 SYNC IRQ V1.0      '
+        fcc     '   CRAIG ALLSOP - 2025 (....)'
+        fcb     0
+        fdb     screen+12*32
+        fcc     '              INTERRUPT ADDRESS '
+        fcc     ' 4090.4090 <- SHOULD MATCH THIS'
+        fcb     0
+        fdb     screen+15*32
+        fcc     '[    .    ]   SECONDS (0-9) ->'
+        fcb     0
+        fdb     0
+results fdb     screen
+        fcc     'RESULT = '
+        fcb     0
 
 
-last	equ	*
+last    equ     *
 
-	end	start
+        end     start

--- a/i1.asm
+++ b/i1.asm
@@ -52,15 +52,15 @@ result	fdb	0
 	bne	.msgs
 
 	lda	#60		program initialization
-	sta	count1
-	sta	count2
-	ldx	timer+2
-	stx	timer
+	sta	>count1
+	sta	>count2
+	ldx	>timer+2
+	stx	>timer
 	ldd	#0
-	std	data
-	std	result
-	std	oldirq
-	std	check
+	std	>data
+	std	>result
+	std	>oldirq
+	std	>check
 
 	ldu	#start		program check
 	ldx	#last-start
@@ -68,14 +68,14 @@ result	fdb	0
 	ldx	#screen+10*32+24
 	lbsr	printhexd
 	lda	#$30		count = 0
-	sta	counter1
-	sta	counter2
-	ldx	$10d
-	stx	oldirq
+	sta	>counter1
+	sta	>counter2
+	ldx	>$10d
+	stx	>oldirq
 	ldx	#intr1
-	stx	$10d		install irq handler
+	stx	>$10d		install irq handler
 	lda	#7
-	sta	$ff03
+	sta	>$ff03
 	clra
 	nop
 	nop
@@ -92,11 +92,11 @@ result	fdb	0
 **************************************************************************
 * start of main program
 *
-top	ldy	timer
+top	ldy	>timer
 	leay	-1,y
 	lbeq	finish
-	sty	timer
-	tst	$ff02		reset for next interrupt
+	sty	>timer
+	tst	>$ff02		reset for next interrupt
 	ldx	#screen
 	sta	,x+
 	andcc   #$ef		enable irq & push this state
@@ -134,7 +134,7 @@ top	ldy	timer
 	nop
 	nop
 	ldy	#intr1		swap to first irq handler
-	sty	$10d		install irq handler
+	sty	>$10d		install irq handler
 	sta	,x+
 	inca
 	cmpx	#screen+8*32
@@ -145,14 +145,14 @@ top	ldy	timer
 	std	,x++
 	std	,x++
 	puls	a
-	jmp	top
+	jmp	>top
 
 	INCLUDE irq.asm
 
-addchk	ldd	check
+addchk	ldd	>check
 	ldx	#2
 	bsr	crc16
-	std	check
+	std	>check
 	rts
 
 	INCLUDE finish.asm

--- a/i2.asm
+++ b/i2.asm
@@ -53,15 +53,15 @@ result	fdb	0
 	bne	.msgs
 
 	lda	#60		program initialization
-	sta	count1
-	sta	count2
-	ldx	timer+2
-	stx	timer
+	sta	>count1
+	sta	>count2
+	ldx	>timer+2
+	stx	>timer
 	ldd	#0
-	std	data
-	std	result
-	std	oldirq
-	std	check
+	std	>data
+	std	>result
+	std	>oldirq
+	std	>check
 
 	ldu	#start		program check
 	ldx	#last-start
@@ -69,14 +69,14 @@ result	fdb	0
 	ldx	#screen+10*32+24
 	lbsr	printhexd
 	lda	#$30		count = 0
-	sta	counter1
-	sta	counter2
-	ldx	$10d
-	stx	oldirq
+	sta	>counter1
+	sta	>counter2
+	ldx	>$10d
+	stx	>oldirq
 	ldx	#intr1
-	stx	$10d		install irq handler
+	stx	>$10d		install irq handler
 	lda	#7
-	sta	$ff03
+	sta	>$ff03
 	clra
 	nop
 	nop
@@ -88,17 +88,17 @@ result	fdb	0
 * start of main program
 *
 
-top	ldy	timer
+top	ldy	>timer
 	leay	-1,y
 	lbeq	finish
-	sty	timer
-	tst	$ff02		reset for next interrupt
+	sty	>timer
+	tst	>$ff02		reset for next interrupt
 	ldx	#screen
 	sta	,x+
 	andcc	#$ef		enable irq & push this state
 	pshs	cc
 	orcc	#$50		disable irq while waiting
-@wait   tst	$ff03		poor mans SYNC (aka Max-10)
+@wait   tst	>$ff03		poor mans SYNC (aka Max-10)
 	bpl	@wait		loop if no interrupt yet
 here	mul			interrupt has occurred!
 	mul
@@ -129,7 +129,7 @@ here	mul			interrupt has occurred!
 	nop
 	nop
 	ldy	#intr1		swap to first irq handler
-	sty	$10d		install irq handler
+	sty	>$10d		install irq handler
 	sta	,x+
 	inca
 	cmpx	#screen+8*32
@@ -140,14 +140,14 @@ here	mul			interrupt has occurred!
 	std	,x++
 	std	,x++
 	puls	a
-	jmp	top
+	jmp	>top
 
 	INCLUDE irq.asm
 
-addchk	ldd	check
+addchk	ldd	>check
 	ldx	#2
 	bsr	crc16
-	std	check
+	std	>check
 	rts
 
 	INCLUDE finish.asm

--- a/i2.asm
+++ b/i2.asm
@@ -35,161 +35,161 @@
 * Craig Allsop, 2025-05-19 - v1.0 - program verification checksum = AE33
 **************************************************************************
 
-	org	$4000
+        org     $4000
 
 **************************************************************************
 * setup screen
 *
-start	bra	.start1
-	fcc	'CA'
-result	fdb	0
+start   bra     .start1
+        fcc     'CA'
+result  fdb     0
 .start1
-	lbsr	clear		clear screen
+        lbsr    clear           clear screen
 
-	ldy	#msgs		print messages to screen
-	ldx	,y++
-.msgs   lbsr	print
-	ldx	,y++
-	bne	.msgs
+        ldy     #msgs           print messages to screen
+        ldx     ,y++
+.msgs   lbsr    print
+        ldx     ,y++
+        bne     .msgs
 
-	lda	#60		program initialization
-	sta	>count1
-	sta	>count2
-	ldx	>timer+2
-	stx	>timer
-	ldd	#0
-	std	>data
-	std	>result
-	std	>oldirq
-	std	>check
+        lda     #60             program initialization
+        sta     >count1
+        sta     >count2
+        ldx     >timer+2
+        stx     >timer
+        ldd     #0
+        std     >data
+        std     >result
+        std     >oldirq
+        std     >check
 
-	ldu	#start		program check
-	ldx	#last-start
-	lbsr	crc16
-	ldx	#screen+10*32+24
-	lbsr	printhexd
-	lda	#$30		count = 0
-	sta	>counter1
-	sta	>counter2
-	ldx	>$10d
-	stx	>oldirq
-	ldx	#intr1
-	stx	>$10d		install irq handler
-	lda	#7
-	sta	>$ff03
-	clra
-	nop
-	nop
-	nop
-	nop
-	nop
+        ldu     #start          program check
+        ldx     #last-start
+        lbsr    crc16
+        ldx     #screen+10*32+24
+        lbsr    printhexd
+        lda     #$30            count = 0
+        sta     >counter1
+        sta     >counter2
+        ldx     >$10d
+        stx     >oldirq
+        ldx     #intr1
+        stx     >$10d           install irq handler
+        lda     #7
+        sta     >$ff03
+        clra
+        nop
+        nop
+        nop
+        nop
+        nop
 
 **************************************************************************
 * start of main program
 *
 
-top	ldy	>timer
-	leay	-1,y
-	lbeq	finish
-	sty	>timer
-	tst	>$ff02		reset for next interrupt
-	ldx	#screen
-	sta	,x+
-	andcc	#$ef		enable irq & push this state
-	pshs	cc
-	orcc	#$50		disable irq while waiting
-@wait   tst	>$ff03		poor mans SYNC (aka Max-10)
-	bpl	@wait		loop if no interrupt yet
-here	mul			interrupt has occurred!
-	mul
-	mul
-	mul
-	mul
-	mul
-	mul
-	mul
-	mul
-	mul
-	mul
-	mul
-	puls	cc		unsuspend interrupt 
-@loop	nop			<- instruction at 4090 - interrupts here
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	ldy	#intr1		swap to first irq handler
-	sty	>$10d		install irq handler
-	sta	,x+
-	inca
-	cmpx	#screen+8*32
-	bne	@loop
-	ldx	#screen+15*32+6
-	pshs	a
-	ldd	#$2020
-	std	,x++
-	std	,x++
-	puls	a
-	jmp	>top
+top     ldy     >timer
+        leay    -1,y
+        lbeq    finish
+        sty     >timer
+        tst     >$ff02          reset for next interrupt
+        ldx     #screen
+        sta     ,x+
+        andcc   #$ef            enable irq & push this state
+        pshs    cc
+        orcc    #$50            disable irq while waiting
+@wait   tst     >$ff03          poor mans SYNC (aka Max-10)
+        bpl     @wait           loop if no interrupt yet
+here    mul                     interrupt has occurred!
+        mul
+        mul
+        mul
+        mul
+        mul
+        mul
+        mul
+        mul
+        mul
+        mul
+        mul
+        puls    cc              unsuspend interrupt 
+@loop   nop                     <- instruction at 4090 - interrupts here
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        ldy     #intr1          swap to first irq handler
+        sty     >$10d           install irq handler
+        sta     ,x+
+        inca
+        cmpx    #screen+8*32
+        bne     @loop
+        ldx     #screen+15*32+6
+        pshs    a
+        ldd     #$2020
+        std     ,x++
+        std     ,x++
+        puls    a
+        jmp     >top
 
-	INCLUDE irq.asm
+        INCLUDE irq.asm
 
-addchk	ldd	>check
-	ldx	#2
-	bsr	crc16
-	std	>check
-	rts
+addchk  ldd     >check
+        ldx     #2
+        bsr     crc16
+        std     >check
+        rts
 
-	INCLUDE finish.asm
+        INCLUDE finish.asm
 
 **************************************************************************
 
-	INCLUDE	printhex.asm
-	INCLUDE	print.asm
-	INCLUDE crc16.asm
-	INCLUDE clear.asm
-count1  fcb	60
-count2  fcb	60
+        INCLUDE printhex.asm
+        INCLUDE print.asm
+        INCLUDE crc16.asm
+        INCLUDE clear.asm
+count1  fcb     60
+count2  fcb     60
 
-timer	fdb	601
-	fdb	601
-oldirq	fdb	0
-data	fdb	0
-check	fdb	0
+timer   fdb     601
+        fdb     601
+oldirq  fdb     0
+data    fdb     0
+check   fdb     0
 
-screen  equ	$400
-escreen equ	$600
-counter1 equ	escreen-2
-counter2 equ	escreen-1
-msgs	fdb	screen+1
-	fcc	' <- SHOULD BE ONE @ HERE'
-	fcb	0
-	fdb	screen+9*32
-	fcc	'   TEST #2 WAIT LOOP IRQ V1.0   '
-	fcc	'   CRAIG ALLSOP - 2025 (....)'
-	fcb	0
-	fdb	screen+12*32
-	fcc	'              INTERRUPT ADDRESS '
-	fcc	' 4090.4090 <- SHOULD MATCH THIS'
-	fcb	0
-	fdb	screen+15*32
-	fcc	'[    .    ]   SECONDS (0-9) ->'
-	fcb	0
-	fdb	0
+screen  equ     $400
+escreen equ     $600
+counter1 equ    escreen-2
+counter2 equ    escreen-1
+msgs    fdb     screen+1
+        fcc     ' <- SHOULD BE ONE @ HERE'
+        fcb     0
+        fdb     screen+9*32
+        fcc     '   TEST #2 WAIT LOOP IRQ V1.0   '
+        fcc     '   CRAIG ALLSOP - 2025 (....)'
+        fcb     0
+        fdb     screen+12*32
+        fcc     '              INTERRUPT ADDRESS '
+        fcc     ' 4090.4090 <- SHOULD MATCH THIS'
+        fcb     0
+        fdb     screen+15*32
+        fcc     '[    .    ]   SECONDS (0-9) ->'
+        fcb     0
+        fdb     0
 
-results	fdb	screen
-	fcc	'RESULT = '
-	fcb	0
-last	equ	*
+results fdb     screen
+        fcc     'RESULT = '
+        fcb     0
+last    equ     *
 
-	end	start
+        end     start

--- a/i3.asm
+++ b/i3.asm
@@ -53,17 +53,17 @@ result	fdb	0
 	bne	.msgs
 
 	lda	#60		program initialization
-	sta	count1
-	sta	count2
-	ldx	timer+2
-	stx	timer
+	sta	>count1
+	sta	>count2
+	ldx	>timer+2
+	stx	>timer
 	ldd	#0
-	std	addr1
-	std	addr3
-	std	data
-	std	result
-	std	oldirq
-	std	check
+	std	>addr1
+	std	>addr3
+	std	>data
+	std	>result
+	std	>oldirq
+	std	>check
 
 	ldu	#start		program check
 	ldx	#last-start
@@ -71,14 +71,14 @@ result	fdb	0
 	ldx	#screen+10*32+24
 	lbsr	printhexd
 	lda	#$30		count = 0
-	sta	counter1
-	sta	counter2
-	ldx	$10d
-	stx	oldirq
+	sta	>counter1
+	sta	>counter2
+	ldx	>$10d
+	stx	>oldirq
 	ldx	#intr1
-	stx	$10d		install irq handler
+	stx	>$10d		install irq handler
 	lda	#7
-	sta	$ff03
+	sta	>$ff03
 	clra
 	nop
 	nop
@@ -92,10 +92,10 @@ result	fdb	0
 * start of main program
 *
 
-top	ldy	timer
+top	ldy	>timer
 	leay	-1,y
 	lbeq	finish
-	sty	timer
+	sty	>timer
 	ldx	#screen
 	sta	,x+
 	nop
@@ -114,8 +114,8 @@ top	ldy	timer
 	nop
 	nop
 	andcc	#$ef		enable irq
-	tst	$ff02		reset for next interrupt
-@wait   tst	$ff03		poor mans SYNC (aka Max-10)
+	tst	>$ff02		reset for next interrupt
+@wait   tst	>$ff03		poor mans SYNC (aka Max-10)
 	bpl	@wait		loop if no interrupt yet
 @loop	nop			<- instruction at 4090 - interrupts here
 	nop
@@ -142,21 +142,21 @@ top	ldy	timer
 	std	,x++
 	std	,x++
 	puls	a
-	jmp	top
+	jmp	>top
 
 **************************************************************************
 * interrupt handler
 **************************************************************************
-intr1   dec	count1		decrement count
+intr1   dec	>count1		decrement count
 	bne	.i1
 	lda	#60		reset counter back to 60
-	sta	count1
-	lda	counter1	increment bottom corner every second
+	sta	>count1
+	lda	>counter1	increment bottom corner every second
 	cmpa	#$39
 	bne	.i2
 	lda	#$2f
 .i2	inca
-	sta	counter1
+	sta	>counter1
 .i1	ldd	10,s		write address interrupted at
 	andb	#3
 	ldx	#addr1
@@ -165,7 +165,7 @@ intr1   dec	count1		decrement count
 	ldx	#screen+15*32+1
 	lbsr	printhexd
 	ldx	#intr2		swap to second irq handler
-	stx	$10d		install irq handler
+	stx	>$10d		install irq handler
 	leau	10,s
 	bsr	addchk
 	ldu	#escreen-2
@@ -176,40 +176,40 @@ intr1   dec	count1		decrement count
 	rti			end interrupt handler
 
 
-intr2   dec	count2		decrement count
+intr2   dec	>count2		decrement count
 	bne	.i1
 	lda	#60		reset counter back to 60
-	sta	count2
-	lda	counter2	increment bottom corner every second
+	sta	>count2
+	lda	>counter2	increment bottom corner every second
 	cmpa	#$39
 	bne	.i2
 	lda	#$2f
 .i2	inca
-	sta	counter2
+	sta	>counter2
 .i1	ldd	10,s		write address interrupted at
 	ldx	#screen+15*32+6
 	bsr	printhexd
 	ldx	#intr1		swap to first irq handler
-	stx	$10d		install irq handler
+	stx	>$10d		install irq handler
 	ldx	#top		reset loop to top
 	stx	10,s
 	leau	10,s
 	bsr	addchk
-	lda	$ff02		reset for next interrupt
+	lda	>$ff02		reset for next interrupt
 	rti			end interrupt handler	
 
-addchk	ldd	check
+addchk	ldd	>check
 	ldx	#2
 	bsr	crc16
-	std	check
+	std	>check
 	rts
 
-finish	ldy	oldirq
-	sty	$10d
+finish	ldy	>oldirq
+	sty	>$10d
 	bsr	cleartop
 	ldu	#escreen-2
 	bsr	addchk
-	std	result
+	std	>result
 	ldy	#results
 	ldx	,y++
 	bsr	print
@@ -218,9 +218,9 @@ finish	ldy	oldirq
 	ldy	#tally
 	ldx	,y++
 	bsr	print
-	ldd	addr1
+	ldd	>addr1
 	bsr	printhexd
-	ldd	addr3
+	ldd	>addr3
 	bsr	printhexd
 
 	rts

--- a/i3.asm
+++ b/i3.asm
@@ -35,244 +35,244 @@
 * Craig Allsop, 2025-05-22 - v1.0 - program verification checksum = 09C8
 **************************************************************************
 
-	org	$4000
+        org     $4000
 
 **************************************************************************
 * setup screen
 *
-start	bra	.start1
-	fcc	'CA'
-result	fdb	0
+start   bra     .start1
+        fcc     'CA'
+result  fdb     0
 .start1
-	lbsr	clear		clear screen
+        lbsr    clear           clear screen
 
-	ldy	#msgs		print messages to screen
-	ldx	,y++
-.msgs   lbsr	print
-	ldx	,y++
-	bne	.msgs
+        ldy     #msgs           print messages to screen
+        ldx     ,y++
+.msgs   lbsr    print
+        ldx     ,y++
+        bne     .msgs
 
-	lda	#60		program initialization
-	sta	>count1
-	sta	>count2
-	ldx	>timer+2
-	stx	>timer
-	ldd	#0
-	std	>addr1
-	std	>addr3
-	std	>data
-	std	>result
-	std	>oldirq
-	std	>check
+        lda     #60             program initialization
+        sta     >count1
+        sta     >count2
+        ldx     >timer+2
+        stx     >timer
+        ldd     #0
+        std     >addr1
+        std     >addr3
+        std     >data
+        std     >result
+        std     >oldirq
+        std     >check
 
-	ldu	#start		program check
-	ldx	#last-start
-	lbsr	crc16
-	ldx	#screen+10*32+24
-	lbsr	printhexd
-	lda	#$30		count = 0
-	sta	>counter1
-	sta	>counter2
-	ldx	>$10d
-	stx	>oldirq
-	ldx	#intr1
-	stx	>$10d		install irq handler
-	lda	#7
-	sta	>$ff03
-	clra
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
+        ldu     #start          program check
+        ldx     #last-start
+        lbsr    crc16
+        ldx     #screen+10*32+24
+        lbsr    printhexd
+        lda     #$30            count = 0
+        sta     >counter1
+        sta     >counter2
+        ldx     >$10d
+        stx     >oldirq
+        ldx     #intr1
+        stx     >$10d           install irq handler
+        lda     #7
+        sta     >$ff03
+        clra
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
 
 **************************************************************************
 * start of main program
 *
 
-top	ldy	>timer
-	leay	-1,y
-	lbeq	finish
-	sty	>timer
-	ldx	#screen
-	sta	,x+
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	andcc	#$ef		enable irq
-	tst	>$ff02		reset for next interrupt
-@wait   tst	>$ff03		poor mans SYNC (aka Max-10)
-	bpl	@wait		loop if no interrupt yet
-@loop	nop			<- instruction at 4090 - interrupts here
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	sta	,x+
-	inca
-	cmpx	#screen+8*32
-	bne	@loop
-	ldx	#screen+15*32+6
-	pshs	a
-	ldd	#$2020
-	std	,x++
-	std	,x++
-	puls	a
-	jmp	>top
+top     ldy     >timer
+        leay    -1,y
+        lbeq    finish
+        sty     >timer
+        ldx     #screen
+        sta     ,x+
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        andcc   #$ef            enable irq
+        tst     >$ff02          reset for next interrupt
+@wait   tst     >$ff03          poor mans SYNC (aka Max-10)
+        bpl     @wait           loop if no interrupt yet
+@loop   nop                     <- instruction at 4090 - interrupts here
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        sta     ,x+
+        inca
+        cmpx    #screen+8*32
+        bne     @loop
+        ldx     #screen+15*32+6
+        pshs    a
+        ldd     #$2020
+        std     ,x++
+        std     ,x++
+        puls    a
+        jmp     >top
 
 **************************************************************************
 * interrupt handler
 **************************************************************************
-intr1   dec	>count1		decrement count
-	bne	.i1
-	lda	#60		reset counter back to 60
-	sta	>count1
-	lda	>counter1	increment bottom corner every second
-	cmpa	#$39
-	bne	.i2
-	lda	#$2f
-.i2	inca
-	sta	>counter1
-.i1	ldd	10,s		write address interrupted at
-	andb	#3
-	ldx	#addr1
-	inc	b,x
-	ldd	10,s
-	ldx	#screen+15*32+1
-	lbsr	printhexd
-	ldx	#intr2		swap to second irq handler
-	stx	>$10d		install irq handler
-	leau	10,s
-	bsr	addchk
-	ldu	#escreen-2
-	bsr	addchk
-	ldu	#screen
-	bsr	addchk
-	*lda	$ff02		skip this
-	rti			end interrupt handler
+intr1   dec     >count1         decrement count
+        bne     .i1
+        lda     #60             reset counter back to 60
+        sta     >count1
+        lda     >counter1       increment bottom corner every second
+        cmpa    #$39
+        bne     .i2
+        lda     #$2f
+.i2     inca
+        sta     >counter1
+.i1     ldd     10,s            write address interrupted at
+        andb    #3
+        ldx     #addr1
+        inc     b,x
+        ldd     10,s
+        ldx     #screen+15*32+1
+        lbsr    printhexd
+        ldx     #intr2          swap to second irq handler
+        stx     >$10d           install irq handler
+        leau    10,s
+        bsr     addchk
+        ldu     #escreen-2
+        bsr     addchk
+        ldu     #screen
+        bsr     addchk
+        *lda    $ff02           skip this
+        rti                     end interrupt handler
 
 
-intr2   dec	>count2		decrement count
-	bne	.i1
-	lda	#60		reset counter back to 60
-	sta	>count2
-	lda	>counter2	increment bottom corner every second
-	cmpa	#$39
-	bne	.i2
-	lda	#$2f
-.i2	inca
-	sta	>counter2
-.i1	ldd	10,s		write address interrupted at
-	ldx	#screen+15*32+6
-	bsr	printhexd
-	ldx	#intr1		swap to first irq handler
-	stx	>$10d		install irq handler
-	ldx	#top		reset loop to top
-	stx	10,s
-	leau	10,s
-	bsr	addchk
-	lda	>$ff02		reset for next interrupt
-	rti			end interrupt handler	
+intr2   dec     >count2         decrement count
+        bne     .i1
+        lda     #60             reset counter back to 60
+        sta     >count2
+        lda     >counter2       increment bottom corner every second
+        cmpa    #$39
+        bne     .i2
+        lda     #$2f
+.i2     inca
+        sta     >counter2
+.i1     ldd     10,s            write address interrupted at
+        ldx     #screen+15*32+6
+        bsr     printhexd
+        ldx     #intr1          swap to first irq handler
+        stx     >$10d           install irq handler
+        ldx     #top            reset loop to top
+        stx     10,s
+        leau    10,s
+        bsr     addchk
+        lda     >$ff02          reset for next interrupt
+        rti                     end interrupt handler   
 
-addchk	ldd	>check
-	ldx	#2
-	bsr	crc16
-	std	>check
-	rts
+addchk  ldd     >check
+        ldx     #2
+        bsr     crc16
+        std     >check
+        rts
 
-finish	ldy	>oldirq
-	sty	>$10d
-	bsr	cleartop
-	ldu	#escreen-2
-	bsr	addchk
-	std	>result
-	ldy	#results
-	ldx	,y++
-	bsr	print
-	bsr	printhexd
+finish  ldy     >oldirq
+        sty     >$10d
+        bsr     cleartop
+        ldu     #escreen-2
+        bsr     addchk
+        std     >result
+        ldy     #results
+        ldx     ,y++
+        bsr     print
+        bsr     printhexd
 
-	ldy	#tally
-	ldx	,y++
-	bsr	print
-	ldd	>addr1
-	bsr	printhexd
-	ldd	>addr3
-	bsr	printhexd
+        ldy     #tally
+        ldx     ,y++
+        bsr     print
+        ldd     >addr1
+        bsr     printhexd
+        ldd     >addr3
+        bsr     printhexd
 
-	rts
+        rts
 
 **************************************************************************
 
-	INCLUDE	printhex.asm
-	INCLUDE	print.asm
-	INCLUDE crc16.asm
-	INCLUDE clear.asm
-count1  fcb	60
-count2  fcb	60
+        INCLUDE printhex.asm
+        INCLUDE print.asm
+        INCLUDE crc16.asm
+        INCLUDE clear.asm
+count1  fcb     60
+count2  fcb     60
 
-addr1	fcb	0
-addr2	fcb	0
-addr3	fcb	0
-addr4	fcb	0
+addr1   fcb     0
+addr2   fcb     0
+addr3   fcb     0
+addr4   fcb     0
 
-timer	fdb	601
-	fdb	601
-oldirq	fdb	0
-data	fdb	0
-check	fdb	0
+timer   fdb     601
+        fdb     601
+oldirq  fdb     0
+data    fdb     0
+check   fdb     0
 
-screen  equ	$400
-escreen equ	$600
-counter1 equ	escreen-2
-counter2 equ	escreen-1
-msgs	fdb	screen+1
-	fcc	' <- SHOULD BE ONE @ HERE'
-	fcb	0
-	fdb	screen+9*32
-	fcc	' TEST #3 WAIT ACT LOOP IRQ V1.0 '
-	fcc	'   CRAIG ALLSOP - 2025 (....)'
-	fcb	0
-	fdb	screen+12*32
-	fcc	'              INTERRUPT ADDRESS '
-	fcc	' 4090.4090 <- SHOULD MATCH THIS'
-	fcb	0
-	fdb	screen+15*32
-	fcc	'[    .    ]   SECONDS (0-9) ->'
-	fcb	0
-	fdb	0
+screen  equ     $400
+escreen equ     $600
+counter1 equ    escreen-2
+counter2 equ    escreen-1
+msgs    fdb     screen+1
+        fcc     ' <- SHOULD BE ONE @ HERE'
+        fcb     0
+        fdb     screen+9*32
+        fcc     ' TEST #3 WAIT ACT LOOP IRQ V1.0 '
+        fcc     '   CRAIG ALLSOP - 2025 (....)'
+        fcb     0
+        fdb     screen+12*32
+        fcc     '              INTERRUPT ADDRESS '
+        fcc     ' 4090.4090 <- SHOULD MATCH THIS'
+        fcb     0
+        fdb     screen+15*32
+        fcc     '[    .    ]   SECONDS (0-9) ->'
+        fcb     0
+        fdb     0
 
-results	fdb	screen
-	fcc	'RESULT = '
-	fcb	0
+results fdb     screen
+        fcc     'RESULT = '
+        fcb     0
 
-tally	fdb	screen+1*32
-	fcc	'TALLY = '
-	fcb	0
+tally   fdb     screen+1*32
+        fcc     'TALLY = '
+        fcb     0
 
-last	equ	*
+last    equ     *
 
-	end	start
+        end     start

--- a/irq.asm
+++ b/irq.asm
@@ -3,21 +3,21 @@
 *
 * Craig Allsop - 2025/05/20
 **************************************************************************
-intr1   dec	count1		decrement count
+intr1   dec	>count1		decrement count
 	bne	.i1
 	lda	#60		reset counter back to 60
-	sta	count1
-	lda	counter1	increment bottom corner every second
+	sta	>count1
+	lda	>counter1	increment bottom corner every second
 	cmpa	#$39
 	bne	.i2
 	lda	#$2f
 .i2	inca
-	sta	counter1
+	sta	>counter1
 .i1	ldd	10,s		write address interrupted at
 	ldx	#screen+15*32+1
 	bsr	printhexd
 	ldx	#intr2		swap to second irq handler
-	stx	$10d		install irq handler
+	stx	>$10d		install irq handler
 	leau	10,s
 	bsr	addchk
 	ldu	#escreen-2
@@ -28,24 +28,24 @@ intr1   dec	count1		decrement count
 	rti			end interrupt handler
 
 
-intr2   dec	count2		decrement count
+intr2   dec	>count2		decrement count
 	bne	.i1
 	lda	#60		reset counter back to 60
-	sta	count2
-	lda	counter2	increment bottom corner every second
+	sta	>count2
+	lda	>counter2	increment bottom corner every second
 	cmpa	#$39
 	bne	.i2
 	lda	#$2f
 .i2	inca
-	sta	counter2
+	sta	>counter2
 .i1	ldd	10,s		write address interrupted at
 	ldx	#screen+15*32+6
 	bsr	printhexd
 	ldx	#intr1		swap to first irq handler
-	stx	$10d		install irq handler
+	stx	>$10d		install irq handler
 	ldx	#top		reset loop to top
 	stx	10,s
 	leau	10,s
 	bsr	addchk
-	lda	$ff02		reset for next interrupt
+	lda	>$ff02		reset for next interrupt
 	rti			end interrupt handler	

--- a/irq.asm
+++ b/irq.asm
@@ -3,49 +3,49 @@
 *
 * Craig Allsop - 2025/05/20
 **************************************************************************
-intr1   dec	>count1		decrement count
-	bne	.i1
-	lda	#60		reset counter back to 60
-	sta	>count1
-	lda	>counter1	increment bottom corner every second
-	cmpa	#$39
-	bne	.i2
-	lda	#$2f
-.i2	inca
-	sta	>counter1
-.i1	ldd	10,s		write address interrupted at
-	ldx	#screen+15*32+1
-	bsr	printhexd
-	ldx	#intr2		swap to second irq handler
-	stx	>$10d		install irq handler
-	leau	10,s
-	bsr	addchk
-	ldu	#escreen-2
-	bsr	addchk
-	ldu	#screen
-	bsr	addchk
-	*lda	$ff02		skip this
-	rti			end interrupt handler
+intr1   dec     >count1         decrement count
+        bne     .i1
+        lda     #60             reset counter back to 60
+        sta     >count1
+        lda     >counter1       increment bottom corner every second
+        cmpa    #$39
+        bne     .i2
+        lda     #$2f
+.i2     inca
+        sta     >counter1
+.i1     ldd     10,s            write address interrupted at
+        ldx     #screen+15*32+1
+        bsr     printhexd
+        ldx     #intr2          swap to second irq handler
+        stx     >$10d           install irq handler
+        leau    10,s
+        bsr     addchk
+        ldu     #escreen-2
+        bsr     addchk
+        ldu     #screen
+        bsr     addchk
+        *lda    $ff02           skip this
+        rti                     end interrupt handler
 
 
-intr2   dec	>count2		decrement count
-	bne	.i1
-	lda	#60		reset counter back to 60
-	sta	>count2
-	lda	>counter2	increment bottom corner every second
-	cmpa	#$39
-	bne	.i2
-	lda	#$2f
-.i2	inca
-	sta	>counter2
-.i1	ldd	10,s		write address interrupted at
-	ldx	#screen+15*32+6
-	bsr	printhexd
-	ldx	#intr1		swap to first irq handler
-	stx	>$10d		install irq handler
-	ldx	#top		reset loop to top
-	stx	10,s
-	leau	10,s
-	bsr	addchk
-	lda	>$ff02		reset for next interrupt
-	rti			end interrupt handler	
+intr2   dec     >count2         decrement count
+        bne     .i1
+        lda     #60             reset counter back to 60
+        sta     >count2
+        lda     >counter2       increment bottom corner every second
+        cmpa    #$39
+        bne     .i2
+        lda     #$2f
+.i2     inca
+        sta     >counter2
+.i1     ldd     10,s            write address interrupted at
+        ldx     #screen+15*32+6
+        bsr     printhexd
+        ldx     #intr1          swap to first irq handler
+        stx     >$10d           install irq handler
+        ldx     #top            reset loop to top
+        stx     10,s
+        leau    10,s
+        bsr     addchk
+        lda     >$ff02          reset for next interrupt
+        rti                     end interrupt handler   

--- a/kbchk.asm
+++ b/kbchk.asm
@@ -66,23 +66,23 @@
 SCREEN  equ     $400
 LINE2   equ     SCREEN+32
 LINE4   equ     SCREEN+32*4
-WAIT1   equ     LINE2+5                 ; the wait character pos
-WAIT2   equ     LINE2+6                 ; the 2nd wait character pos
-COUNTER equ     LINE2+15                ; the counter character pos
-SCAN    equ     LINE2+23                ; the keyboard scan
-PRINT   equ     LINE4-1                 ; print position
+WAIT1   equ     LINE2+5         ; the wait character pos
+WAIT2   equ     LINE2+6         ; the 2nd wait character pos
+COUNTER equ     LINE2+15        ; the counter character pos
+SCAN    equ     LINE2+23        ; the keyboard scan
+PRINT   equ     LINE4-1         ; print position
 
-READ    macro                           ; read a keyboard column 
+READ    macro                   ; read a keyboard column 
         rola
-        sta     $ff02
-        ldb     $ff00
+        sta     >$ff02
+        ldb     >$ff00
         stb     ,x+
         endm
 
 
         org     $4000
 start:
-        ldd     #$2020                  ; clear the screen
+        ldd     #$2020          ; clear the screen
         ldx     #SCREEN
 clear:
         std     ,x++
@@ -91,7 +91,7 @@ clear:
 
         ldx     #SCREEN
         ldy     #msg
-showmsg:                                ; show message text
+showmsg:                        ; show message text
         lda     ,y+
         beq     continue
         anda    #~$40
@@ -99,38 +99,38 @@ showmsg:                                ; show message text
         bra     showmsg
 
 continue:
-        lda     #%11000000              ; coco3 mode, mmu, no interrupt to cpu
-        sta     $ff90
-        lda     #2                      ; enable only keyboard interrupt
-        sta     $ff92
+        lda     #%11000000      ; coco3 mode, mmu, no interrupt to cpu
+        sta     >$ff90
+        lda     #2              ; enable only keyboard interrupt
+        sta     >$ff92
 
-        lda     #0                      ; check all keys
-        sta     $ff02
+        lda     #0              ; check all keys
+        sta     >$ff02
 
 top:
-        lda     #'0'                    ; start loop at a zero
-        sta     WAIT1
+        lda     #'0'            ; start loop at a zero
+        sta     >WAIT1
 
-loop:   inc     WAIT1
-        lda     $ff92                   ; wait for keyboard interrupt
+loop:   inc     >WAIT1
+        lda     >$ff92          ; wait for keyboard interrupt
         bne     pressed
         bra     loop
 pressed:
-        inc     COUNTER                 ; count each scan
-        ldx     #SCAN                   ; scan keyboard
+        inc     >COUNTER        ; count each scan
+        ldx     #SCAN           ; scan keyboard
 
-        lda     pressed
-        beq     nopause                 ; if nothing pressed, don't pause
-        jsr     pause                   ; wait (required for a release event, if
-                                        ;       we scan too early we'll read the
-                                        ;       prior pressed state)
+        lda     >pressed
+        beq     nopause         ; if nothing pressed, don't pause
+        jsr     >pause          ; wait (required for a release event, if
+                                ;       we scan too early we'll read the
+                                ;       prior pressed state)
 nopause:
-        clr     ispressed
+        clr     >ispressed
         
-        andcc   #$fe                    ; clear carry
+        andcc   #$fe            ; clear carry
         lda     #$ff
 
-        READ                            ; rola and read keyboard to x
+        READ                    ; rola and read keyboard to x
         READ
         READ
         READ
@@ -139,33 +139,33 @@ nopause:
         READ
         READ
 
-        lda     #' '                    ; show the space while in 2nd loop
-        sta     WAIT1
+        lda     #' '            ; show the space while in 2nd loop
+        sta     >WAIT1
 
-        lda     #'0'                    ; start loop at a zero
-        sta     WAIT2
+        lda     #'0'            ; start loop at a zero
+        sta     >WAIT2
 
-        lda     #0                      ; check all keys
-        sta     $ff02
+        lda     #0              ; check all keys
+        sta     >$ff02
 
-wait:   inc     WAIT2
-        lda     $ff92
-        bne     wait                    ; wait for clear flag (never waits?)
+wait:   inc     >WAIT2
+        lda     >$ff92
+        bne     wait            ; wait for clear flag (never waits?)
 
-        ldx     #SCAN                   ; decode key
+        ldx     #SCAN           ; decode key
         ldy     #table
 print:
         lda     ,x+
         ldb     #7
 @next:
         rora
-        bcs     @nokey                  ; found a key?
-        pshs    d,x                     ; print the key & scroll
+        bcs     @nokey          ; found a key?
+        pshs    d,x             ; print the key & scroll
         lda     ,y
-        sta     PRINT
+        sta     >PRINT
         bsr     scroll
         puls    d,x
-        inc     ispressed               ; something was pressed
+        inc     >ispressed      ; something was pressed
 @nokey:
         leay    1,y
         decb
@@ -175,7 +175,7 @@ print:
         lbra    top
 
 scroll:
-        ldx     #PRINT-29               ; scroll decoded keys left
+        ldx     #PRINT-29       ; scroll decoded keys left
 @loop:
         ldd     ,x+
         std     -2,x
@@ -183,7 +183,7 @@ scroll:
         bne     @loop
         rts
 
-pause:  lda     #20                ; a small pause
+pause:  lda     #20             ; a small pause
 @loop:  deca
         bne     @loop
         rts
@@ -191,6 +191,7 @@ pause:  lda     #20                ; a small pause
 ispressed:
         fcb     0
 msg:    fcn     '  KEYBOARD INTERRUPT TEST 1.04  WAIT[* ] COUNT[0] SCAN[        ]'
+
 
 table:  fcc     '@HPX08e'
         fcc     'AIQY19c'

--- a/mmu1.asm
+++ b/mmu1.asm
@@ -1,0 +1,270 @@
+*
+* mmu bit test v1.04 - Craig Allsop 19/7/2026
+*
+* The following test attempts to write into the MMU registers
+* and compare what was written with a CMP. There are 3 variations
+* of the same test. Each variation has two parts, firstly it
+* writes values <= $3F as MMU registers normally only support
+* reading of the lower 6 bits (to support 512k). The values are:
+*
+* $1A,$25,$0F,$30,$35,$3A
+*
+* The second group of values tests values >= $40, which would apply to
+* machine with 2MB installed. The values are:
+*
+* $85,$80,$C0,$65,$4A,$1E
+*
+* The 3 variations mirror the following routines:
+*
+* 1,2: CMP/BNE - tests bit 6&7 clear as used by LOADM.
+* 3,4: CMP/JMP - tests bit 6 set as used by PEEK.
+* 5,6: CMP/BSR - tests bit 7 set, thrown in for good measure.
+*
+* The expected results are:
+*
+* 1.CMP/BNE($26) 1A250F30353A OK
+*
+* This row should always result in an OK meaning all values written are
+* read back the same, no matter how much memory the machine has.
+* This mirrors what the disk basic LOADM uses.
+*
+* The rest of the tests will return a result that is different
+* than what was written. For a 128k/512k coco3, they should be as
+* follows:
+*
+* 2.CMP/BNE($26) 85 GOT:05
+* 3.CMP/JMP($7E) 1A GOT:5A
+* 4.CMP/JMP($7E) 85 GOT:45
+* 5.CMP/BSR($8D) 1A GOT:9A
+* 6.CMP/BSR($8D) 8580C0 GOT:80
+*
+* For a 2mb coco3, all these tests may return OK given the
+* upper bits should be valid, although its possible some hardware
+* may choose not to support reading back those upper bits despite
+* having 2mb.
+*
+* v1.00 - documentation added
+*
+
+SCREEN	equ	$400
+
+	org	$2000
+start:
+	ldd	#$2020		; clear the screen
+	ldx	#SCREEN
+clear:
+	std	,x++
+	cmpx	#SCREEN+$200
+	bne	clear
+
+
+	ldx	#SCREEN		; show title message
+	ldy	#msg
+	jsr	>showmsg
+
+	leax	-5,x
+	pshs	x
+	ldu	#start		; program check
+	ldx	#last-start
+	ldd	#$beef
+	jsr	>crc16
+	puls	x
+	jsr	>printhexd
+
+	jsr	>crlf
+	jsr	>crlf
+
+	lda	#%11000000	; coco3 mode, mmu, no interrupt to cpu
+	sta	>$ff90
+
+	ldy	#testa		; show test a message (CMP/BNE)
+	jsr	>showmsg
+	jsr	>crlf
+
+	ldy	#msg1		; run test #1
+	ldu	#msg1d
+	jsr	>test
+
+	ldy	#msg2		; run test #2
+	ldu	#msg2d
+	jsr	>test
+
+	ldu	#test2		; switch to test2 function (CMP/JMP)
+	stu	>func+1
+	ldu	#test2a
+	stu	>func2+1
+
+	jsr	>crlf		; show test b message
+	ldy	#testb
+	jsr	>showmsg
+	jsr	>crlf
+
+	ldy	#msg3		; run test #3
+	ldu	#msg3d
+	jsr	>test
+
+	ldy	#msg4		; run test #4
+	ldu	#msg4d
+	jsr	>test
+
+	ldu	#test3		; switch to test3 function (CMP/BSR)
+	stu	>func+1
+	ldu	#test3a
+	stu	>func2+1
+
+	jsr	>crlf		; show test c message
+	ldy	#testc
+	jsr	>showmsg
+	jsr	>crlf
+
+	ldy	#msg5		; run test #5
+	ldu	#msg5d
+	jsr	>test
+
+	ldy	#msg6		; run test #6
+	ldu	#msg6d
+	jsr	>test
+
+	jsr	>crlf		; done message
+	ldy	#done
+	jsr	>showmsg
+
+stop:	jmp	>stop		; wait forever
+
+
+test:
+	jsr	>showmsg
+	clra
+	sta	,-s
+@read:	lda	,u+
+	beq	@testloop
+	sta	,-s
+	bra	@read
+@testloop:
+	ldu	#$ffa2
+@lp:
+	lda	,s+
+	beq	@ok
+	jsr	>printhex
+func:	jsr	>test1
+	bne	@bad
+	bra	@lp
+@bad:	ldb	,s+
+	bne	@bad
+	ldy	#bad
+	jsr	>showmsg
+func2:	jsr	>test1a
+	jsr	>printhex
+	jmp	>@finish
+@ok:
+	ldy	#ok
+	jsr	>showmsg
+@finish:
+	jsr	>crlf
+	rts
+
+	include	"printhex.asm"
+	include "crc16.asm"
+
+showmsg:			; show message text
+	pshs	a,b
+@lp:
+	lda	,y+
+	beq	@c
+	anda	#~$40
+	sta	,x+
+	bra	@lp
+@c:	puls	a,b,pc
+
+crlf:	pshs	a,b
+	tfr	x,d
+	andb	#~$1f
+	addd	#32
+	tfr	d,x
+	puls	a,b,pc
+
+*
+* Here are the test variations:
+*
+test1:
+	sta	,u
+	cmpa	,u
+	bne	.skip
+.skip:	rts
+
+test2:
+	sta	,u
+	cmpa	,u
+	jmp	>.skip
+.skip:	rts
+
+test3:
+	sta	,u
+	cmpa	,u
+	bsr	.skip
+.skip:	rts
+
+
+*
+* Should the above fail, use these to get what cpu read back:
+* as above, they have same following instruction.
+*
+test1a:
+	sta	,u
+	lda	,u
+	bne	.skip
+.skip:	rts
+
+test2a:
+	sta	,u
+	lda	,u
+	jmp	>.skip
+.skip:	rts
+
+test3a:
+	sta	,u
+	lda	,u
+	bsr	.skip
+.skip:	rts
+
+*
+* Test data
+*
+
+screen  equ	$400
+escreen equ	$600
+
+msg:	fcn	' MMU BIT TEST 1.0 - 2026 (    )'
+
+testa:	fcn	'BIT6,7 ZERO:'
+
+msg1:	fcn	'1.CMP/BNE($26) '
+msg1d:	fcb	$3A,$35,$30,$0F,$25,$1A,0
+
+msg2:	fcn	'2.CMP/BNE($26) '
+msg2d:	fcb	$1E,$4A,$65,$C0,$80,$85,0
+
+testb:	fcn	'BIT6 SET:'
+
+msg3:	fcn	'3.CMP/JMP($7E) '
+msg3d:	fcb	$3A,$35,$30,$0F,$25,$1A,0
+
+msg4:	fcn	'4.CMP/JMP($7E) '
+msg4d:	fcb	$1E,$4A,$65,$C0,$80,$85,0
+
+testc:	fcn	'BIT7 SET:'
+
+msg5:	fcn	'5.CMP/BSR($8D) '
+msg5d:	fcb	$3A,$35,$30,$0F,$25,$1A,0
+
+msg6:	fcn	'6.CMP/BSR($8D) '
+msg6d:	fcb	$1E,$4A,$65,$C0,$80,$85,0
+
+ok:	fcn	' OK'
+bad:	fcn	' GOT:'
+
+done:	fcn	'DONE.'
+
+last	equ	*
+
+	end	start

--- a/mmu1.asm
+++ b/mmu1.asm
@@ -46,163 +46,163 @@
 * v1.00 - documentation added
 *
 
-SCREEN	equ	$400
+SCREEN  equ     $400
 
-	org	$2000
+        org     $2000
 start:
-	ldd	#$2020		; clear the screen
-	ldx	#SCREEN
+        ldd     #$2020          ; clear the screen
+        ldx     #SCREEN
 clear:
-	std	,x++
-	cmpx	#SCREEN+$200
-	bne	clear
+        std     ,x++
+        cmpx    #SCREEN+$200
+        bne     clear
 
 
-	ldx	#SCREEN		; show title message
-	ldy	#msg
-	jsr	>showmsg
+        ldx     #SCREEN         ; show title message
+        ldy     #msg
+        jsr     >showmsg
 
-	leax	-5,x
-	pshs	x
-	ldu	#start		; program check
-	ldx	#last-start
-	ldd	#$beef
-	jsr	>crc16
-	puls	x
-	jsr	>printhexd
+        leax    -5,x
+        pshs    x
+        ldu     #start          ; program check
+        ldx     #last-start
+        ldd     #$beef
+        jsr     >crc16
+        puls    x
+        jsr     >printhexd
 
-	jsr	>crlf
-	jsr	>crlf
+        jsr     >crlf
+        jsr     >crlf
 
-	lda	#%11000000	; coco3 mode, mmu, no interrupt to cpu
-	sta	>$ff90
+        lda     #%11000000      ; coco3 mode, mmu, no interrupt to cpu
+        sta     >$ff90
 
-	ldy	#testa		; show test a message (CMP/BNE)
-	jsr	>showmsg
-	jsr	>crlf
+        ldy     #testa          ; show test a message (CMP/BNE)
+        jsr     >showmsg
+        jsr     >crlf
 
-	ldy	#msg1		; run test #1
-	ldu	#msg1d
-	jsr	>test
+        ldy     #msg1           ; run test #1
+        ldu     #msg1d
+        jsr     >test
 
-	ldy	#msg2		; run test #2
-	ldu	#msg2d
-	jsr	>test
+        ldy     #msg2           ; run test #2
+        ldu     #msg2d
+        jsr     >test
 
-	ldu	#test2		; switch to test2 function (CMP/JMP)
-	stu	>func+1
-	ldu	#test2a
-	stu	>func2+1
+        ldu     #test2          ; switch to test2 function (CMP/JMP)
+        stu     >func+1
+        ldu     #test2a
+        stu     >func2+1
 
-	jsr	>crlf		; show test b message
-	ldy	#testb
-	jsr	>showmsg
-	jsr	>crlf
+        jsr     >crlf           ; show test b message
+        ldy     #testb
+        jsr     >showmsg
+        jsr     >crlf
 
-	ldy	#msg3		; run test #3
-	ldu	#msg3d
-	jsr	>test
+        ldy     #msg3           ; run test #3
+        ldu     #msg3d
+        jsr     >test
 
-	ldy	#msg4		; run test #4
-	ldu	#msg4d
-	jsr	>test
+        ldy     #msg4           ; run test #4
+        ldu     #msg4d
+        jsr     >test
 
-	ldu	#test3		; switch to test3 function (CMP/BSR)
-	stu	>func+1
-	ldu	#test3a
-	stu	>func2+1
+        ldu     #test3          ; switch to test3 function (CMP/BSR)
+        stu     >func+1
+        ldu     #test3a
+        stu     >func2+1
 
-	jsr	>crlf		; show test c message
-	ldy	#testc
-	jsr	>showmsg
-	jsr	>crlf
+        jsr     >crlf           ; show test c message
+        ldy     #testc
+        jsr     >showmsg
+        jsr     >crlf
 
-	ldy	#msg5		; run test #5
-	ldu	#msg5d
-	jsr	>test
+        ldy     #msg5           ; run test #5
+        ldu     #msg5d
+        jsr     >test
 
-	ldy	#msg6		; run test #6
-	ldu	#msg6d
-	jsr	>test
+        ldy     #msg6           ; run test #6
+        ldu     #msg6d
+        jsr     >test
 
-	jsr	>crlf		; done message
-	ldy	#done
-	jsr	>showmsg
+        jsr     >crlf           ; done message
+        ldy     #done
+        jsr     >showmsg
 
-stop:	jmp	>stop		; wait forever
+stop:   jmp     >stop           ; wait forever
 
 
 test:
-	jsr	>showmsg
-	clra
-	sta	,-s
-@read:	lda	,u+
-	beq	@testloop
-	sta	,-s
-	bra	@read
+        jsr     >showmsg
+        clra
+        sta     ,-s
+@read:  lda     ,u+
+        beq     @testloop
+        sta     ,-s
+        bra     @read
 @testloop:
-	ldu	#$ffa2
+        ldu     #$ffa2
 @lp:
-	lda	,s+
-	beq	@ok
-	jsr	>printhex
-func:	jsr	>test1
-	bne	@bad
-	bra	@lp
-@bad:	ldb	,s+
-	bne	@bad
-	ldy	#bad
-	jsr	>showmsg
-func2:	jsr	>test1a
-	jsr	>printhex
-	jmp	>@finish
+        lda     ,s+
+        beq     @ok
+        jsr     >printhex
+func:   jsr     >test1
+        bne     @bad
+        bra     @lp
+@bad:   ldb     ,s+
+        bne     @bad
+        ldy     #bad
+        jsr     >showmsg
+func2:  jsr     >test1a
+        jsr     >printhex
+        jmp     >@finish
 @ok:
-	ldy	#ok
-	jsr	>showmsg
+        ldy     #ok
+        jsr     >showmsg
 @finish:
-	jsr	>crlf
-	rts
+        jsr     >crlf
+        rts
 
-	include	"printhex.asm"
-	include "crc16.asm"
+        include "printhex.asm"
+        include "crc16.asm"
 
-showmsg:			; show message text
-	pshs	a,b
+showmsg:                        ; show message text
+        pshs    a,b
 @lp:
-	lda	,y+
-	beq	@c
-	anda	#~$40
-	sta	,x+
-	bra	@lp
-@c:	puls	a,b,pc
+        lda     ,y+
+        beq     @c
+        anda    #~$40
+        sta     ,x+
+        bra     @lp
+@c:     puls    a,b,pc
 
-crlf:	pshs	a,b
-	tfr	x,d
-	andb	#~$1f
-	addd	#32
-	tfr	d,x
-	puls	a,b,pc
+crlf:   pshs    a,b
+        tfr     x,d
+        andb    #~$1f
+        addd    #32
+        tfr     d,x
+        puls    a,b,pc
 
 *
 * Here are the test variations:
 *
 test1:
-	sta	,u
-	cmpa	,u
-	bne	.skip
-.skip:	rts
+        sta     ,u
+        cmpa    ,u
+        bne     .skip
+.skip:  rts
 
 test2:
-	sta	,u
-	cmpa	,u
-	jmp	>.skip
-.skip:	rts
+        sta     ,u
+        cmpa    ,u
+        jmp     >.skip
+.skip:  rts
 
 test3:
-	sta	,u
-	cmpa	,u
-	bsr	.skip
-.skip:	rts
+        sta     ,u
+        cmpa    ,u
+        bsr     .skip
+.skip:  rts
 
 
 *
@@ -210,61 +210,61 @@ test3:
 * as above, they have same following instruction.
 *
 test1a:
-	sta	,u
-	lda	,u
-	bne	.skip
-.skip:	rts
+        sta     ,u
+        lda     ,u
+        bne     .skip
+.skip:  rts
 
 test2a:
-	sta	,u
-	lda	,u
-	jmp	>.skip
-.skip:	rts
+        sta     ,u
+        lda     ,u
+        jmp     >.skip
+.skip:  rts
 
 test3a:
-	sta	,u
-	lda	,u
-	bsr	.skip
-.skip:	rts
+        sta     ,u
+        lda     ,u
+        bsr     .skip
+.skip:  rts
 
 *
 * Test data
 *
 
-screen  equ	$400
-escreen equ	$600
+screen  equ     $400
+escreen equ     $600
 
-msg:	fcn	' MMU BIT TEST 1.0 - 2026 (    )'
+msg:    fcn     ' MMU BIT TEST 1.0 - 2026 (    )'
 
-testa:	fcn	'BIT6,7 ZERO:'
+testa:  fcn     'BIT6,7 ZERO:'
 
-msg1:	fcn	'1.CMP/BNE($26) '
-msg1d:	fcb	$3A,$35,$30,$0F,$25,$1A,0
+msg1:   fcn     '1.CMP/BNE($26) '
+msg1d:  fcb     $3A,$35,$30,$0F,$25,$1A,0
 
-msg2:	fcn	'2.CMP/BNE($26) '
-msg2d:	fcb	$1E,$4A,$65,$C0,$80,$85,0
+msg2:   fcn     '2.CMP/BNE($26) '
+msg2d:  fcb     $1E,$4A,$65,$C0,$80,$85,0
 
-testb:	fcn	'BIT6 SET:'
+testb:  fcn     'BIT6 SET:'
 
-msg3:	fcn	'3.CMP/JMP($7E) '
-msg3d:	fcb	$3A,$35,$30,$0F,$25,$1A,0
+msg3:   fcn     '3.CMP/JMP($7E) '
+msg3d:  fcb     $3A,$35,$30,$0F,$25,$1A,0
 
-msg4:	fcn	'4.CMP/JMP($7E) '
-msg4d:	fcb	$1E,$4A,$65,$C0,$80,$85,0
+msg4:   fcn     '4.CMP/JMP($7E) '
+msg4d:  fcb     $1E,$4A,$65,$C0,$80,$85,0
 
-testc:	fcn	'BIT7 SET:'
+testc:  fcn     'BIT7 SET:'
 
-msg5:	fcn	'5.CMP/BSR($8D) '
-msg5d:	fcb	$3A,$35,$30,$0F,$25,$1A,0
+msg5:   fcn     '5.CMP/BSR($8D) '
+msg5d:  fcb     $3A,$35,$30,$0F,$25,$1A,0
 
-msg6:	fcn	'6.CMP/BSR($8D) '
-msg6d:	fcb	$1E,$4A,$65,$C0,$80,$85,0
+msg6:   fcn     '6.CMP/BSR($8D) '
+msg6d:  fcb     $1E,$4A,$65,$C0,$80,$85,0
 
-ok:	fcn	' OK'
-bad:	fcn	' GOT:'
+ok:     fcn     ' OK'
+bad:    fcn     ' GOT:'
 
-done:	fcn	'DONE.'
+done:   fcn     'DONE.'
 
-last	equ	*
+last    equ     *
 
-	end	start
+        end     start

--- a/print.asm
+++ b/print.asm
@@ -6,11 +6,11 @@
 *
 * Craig Allsop - 2025/05/20
 **************************************************************************
-print   pshs	a
-.loop   lda	,y+
-	beq	.done
-	anda	#~$40
-	sta	,x+
-	bra	.loop
-.done   puls	a,pc
+print   pshs    a
+.loop   lda     ,y+
+        beq     .done
+        anda    #~$40
+        sta     ,x+
+        bra     .loop
+.done   puls    a,pc
 

--- a/printhex.asm
+++ b/printhex.asm
@@ -21,11 +21,11 @@ printhex
 	andb	#$f
 	addd	#$3030		make ascii
 	cmpa	#$3A		adjust for a-f
-	blt	.hex1
+	blt	@hex1
 	suba	#$39
-.hex1   cmpb	#$3A
-	blt	.hex2
+@hex1   cmpb	#$3A
+	blt	@hex2
 	subb	#$39
-.hex2   std	,x++		print it to screen
+@hex2   std	,x++		print it to screen
 	puls	a,b,pc
 

--- a/printhex.asm
+++ b/printhex.asm
@@ -7,25 +7,25 @@
 **************************************************************************
 
 printhexd
-	bsr	printhex
-	tfr	b,a
-	bsr	printhex
-	rts
+        bsr     printhex
+        tfr     b,a
+        bsr     printhex
+        rts
 printhex
-	pshs	a,b
-	tfr	a,b		split into nibbles
-	lsra
-	lsra
-	lsra
-	lsra
-	andb	#$f
-	addd	#$3030		make ascii
-	cmpa	#$3A		adjust for a-f
-	blt	@hex1
-	suba	#$39
-@hex1   cmpb	#$3A
-	blt	@hex2
-	subb	#$39
-@hex2   std	,x++		print it to screen
-	puls	a,b,pc
+        pshs    a,b
+        tfr     a,b             split into nibbles
+        lsra
+        lsra
+        lsra
+        lsra
+        andb    #$f
+        addd    #$3030          make ascii
+        cmpa    #$3A            adjust for a-f
+        blt     @hex1
+        suba    #$39
+@hex1   cmpb    #$3A
+        blt     @hex2
+        subb    #$39
+@hex2   std     ,x++            print it to screen
+        puls    a,b,pc
 


### PR DESCRIPTION
This adds MMU1 test. This tests the MMU bits in various scenarios, including LOADM, PEEK. It goes someway to explaining the behavior of the upper bits. This demonstrates that they are predictable and also that using LOADM to plug MMU with values during loading should pose no issues for machines <= 512k.